### PR TITLE
Refactor: Streamline notebook processing and remove Chrome dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,17 +27,13 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install Google Chrome
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y google-chrome-stable
-
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          # Dépendances supplémentaires pour l'export de graphiques
-          pip install kaleido
+
+      - name: Install Playwright Browsers
+        run: playwright install --with-deps
 
       - name: Process notebooks and generate images
         run: python process_notebook.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ plotly
 kaleido
 matplotlib
 folium
-selenium
-webdriver-manager
 geopandas
 gradio
+playwright


### PR DESCRIPTION
This commit introduces a major overhaul of the notebook processing workflow to make it more user-friendly and robust. It also removes the hard dependency on a system-installed Google Chrome for generating visualization screenshots.

Key changes:

1.  **Simplified Workflow:** The `process_notebook.py` script now processes `.ipynb` files directly from the root directory. Upon successful processing, the executed notebook and its generated PNG thumbnail are moved to the `published/notebooks/` directory. This creates an intuitive workflow where you can simply add a notebook to the root of the repository and have it automatically appear in the gallery.

2.  **Chrome Dependency Removed:** The `selenium` and `webdriver-manager` libraries have been replaced with `playwright`. The `capture_folium_map` function now uses Playwright to take screenshots of Folium maps. Playwright manages its own browser binaries, which makes the process more reliable and suitable for CI/CD environments.

3.  **Updated GitHub Actions:** The workflow file (`.github/workflows/main.yml`) has been updated to reflect these changes. The explicit Google Chrome installation step has been removed and replaced with a step to install Playwright's browsers (`playwright install --with-deps`), making the CI process cleaner and more efficient.